### PR TITLE
lx-music-desktop: init at 2.7.0

### DIFF
--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+
+, dpkg
+, libGL
+, systemd
+, electron_28
+
+, commandLineArgs ? ""
+}:
+
+let
+  pname = "lx-music-desktop";
+  version = "2.7.0";
+
+  buildUrl = version: arch: "https://github.com/lyswhut/lx-music-desktop/releases/download/v${version}/lx-music-desktop_${version}_${arch}.deb";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = buildUrl version "amd64";
+      hash = "sha256-+mCAFfiJwa+RQ/9vnSPDrC1LoLIoZyFUEJAF6sXdqRM=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = buildUrl version "arm64";
+      hash = "sha256-fDlgHJqoZLGnUuZeZGdocYLbsE02QBrWPKS31fbGThk=";
+    };
+
+    armv7l-linux = fetchurl {
+      url = buildUrl version "armv7l";
+      hash = "sha256-X6EXsBvTbPGXCJ+ektMCMGDG2zqGKBvWT/TwjGFL3ug=";
+    };
+  };
+
+  host = stdenv.hostPlatform.system;
+  src = srcs.${host} or (throw "Unsupported system: ${host}");
+
+  runtimeLibs = lib.makeLibraryPath [
+    libGL
+    stdenv.cc.cc.lib
+  ];
+in
+  stdenv.mkDerivation {
+    inherit pname version src;
+  
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
+
+    runtimeDependencies = map lib.getLib [
+      systemd
+    ];
+  
+    installPhase = ''
+      runHook preInstall
+  
+      mkdir -p $out/bin $out/opt
+      cp -r opt/resources opt/locales $out/opt
+      cp -r usr/share $out/share
+  
+      substituteInPlace $out/share/applications/lx-music-desktop.desktop \
+          --replace "/opt/lx-music-desktop/lx-music-desktop" "$out/bin/lx-music-desktop" \
+  
+      runHook postInstall
+    '';
+  
+    postFixup = ''
+      makeWrapper ${electron_28}/bin/electron $out/bin/lx-music-desktop \
+          --add-flags $out/opt/lx-music-desktop/resources/app.asar \
+          --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+          --add-flags ${lib.escapeShellArg commandLineArgs} \
+    '';
+  
+    meta = with lib; {
+      description = "A music software based on Electron and Vue";
+      homepage = "https://github.com/lyswhut/lx-music-desktop";
+      changelog = "https://github.com/lyswhut/lx-music-desktop/releases/tag/v${version}";
+      license = licenses.asl20;
+      platforms = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      mainProgram = "lx-music-desktop";
+      maintainers = with maintainers; [ oo-infty ];
+    };
+  }


### PR DESCRIPTION
## Description of changes

lx-music-desktop is a music software based on Electron and Vue, which provides convenient access to varieties of music platforms in China through one common UI. Homepage: https://github.com/lyswhut/lx-music-desktop.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
